### PR TITLE
feat: expand DSPy ruleset with code analysis module

### DIFF
--- a/agent-rules/REFACTORING_REPORT.md
+++ b/agent-rules/REFACTORING_REPORT.md
@@ -1,0 +1,18 @@
+# Refactoring Report
+
+## Major Changes
+- Renamed `dspy/RULEBOOK.md` to `dspy/DSPY_RULES.md` and clarified rule precedence.
+- Added `AnalyzeCode` signature and `ReviewModule` for comprehensive code analysis.
+- Expanded `architecture.md` and `modules.py` to include the new module and updated pipeline ordering.
+- Introduced `TRACEABILITY.md` mapping legacy `.mdc` rules to DSPy signatures and modules.
+
+## Conflict Resolution
+- Unified multiple commit conventions into a single conventional commit policy.
+- Consolidated scattered documentation rules under `UpdateDocs` and `DocModule`.
+
+## Deprecated Practices
+- Legacy `.mdc` rule files are preserved in `legacy-rules/` but superseded by DSPy modules.
+
+## New Rules
+- Code analysis now requires explicit quality, performance, and security review before merge.
+- Rule hierarchy enforced: global → project → sub-directory.

--- a/agent-rules/RULES_SUMMARY.md
+++ b/agent-rules/RULES_SUMMARY.md
@@ -8,4 +8,4 @@ This repository has been refactored around a DSPy architecture. Key practices in
 - Comprehensive code analysis before merge
 - Continuous improvement via feedback loops
 
-Legacy rule files now live in `legacy-rules/`. Active guidance resides in `dspy/`.
+Legacy rule files now live in `legacy-rules/`. Active guidance resides in `dspy/` via `DSPY_RULES.md`.

--- a/agent-rules/dspy/DSPY_RULES.md
+++ b/agent-rules/dspy/DSPY_RULES.md
@@ -2,6 +2,11 @@
 
 This rulebook consolidates the essential practices from the legacy agent guidelines and expresses them in DSPy-friendly terms.
 
+## Precedence Hierarchy
+- **Global** – organization-wide defaults from repository root.
+- **Project** – rules in this `agent-rules/dspy` directory.
+- **Sub-directory** – component specific guidance stored next to code.
+
 ## Core Development Practices
 - **Issue Analysis** – produce structured specs with summary, problem statement, technical approach, implementation and test plans.
 - **Task Implementation** – evaluate strategies, consider trade‑offs, and outline clear implementation steps.
@@ -16,5 +21,7 @@ When overlapping guidance existed (e.g., multiple commit conventions), the more 
 ## Directory Structure
 - `dspy/` – active DSPy‑aligned rules and modules
 - `legacy-rules/` – original unrefactored rule sets
+
+See `TRACEABILITY.md` for mappings from legacy rules to their DSPy equivalents.
 
 Refer to `architecture.md` for module boundaries and `signatures.py` for formal DSPy signatures.

--- a/agent-rules/dspy/TRACEABILITY.md
+++ b/agent-rules/dspy/TRACEABILITY.md
@@ -1,0 +1,16 @@
+# Legacy to DSPy Traceability
+
+| Legacy Rule | DSPy Signature | Module |
+| --- | --- | --- |
+| project/analyze-issue.mdc | AnalyzeIssue | AnalyzerModule |
+| project/implement-task.mdc | ImplementTask | ImplementerModule |
+| project/code-analysis.mdc | AnalyzeCode | ReviewModule |
+| project/check.mdc | RunChecks | CheckModule |
+| project/commit.mdc, project/commit-fast.mdc | CommitCode | CommitModule |
+| project/update-docs.mdc, project/create-docs.mdc, project/add-to-changelog.mdc | UpdateDocs | DocModule |
+| project/bug-fix.mdc | AnalyzeIssue → ImplementTask → ReviewModule → CheckModule → DocModule → CommitModule |
+| project/continuous-improvement.mdc | AnalyzeCode & UpdateDocs | ReviewModule & DocModule |
+| global/github-issue-creation.mdc | AnalyzeIssue | AnalyzerModule |
+| global/mcp-peekaboo-setup.mdc, global/mcp-sync-rule.md | RunChecks & UpdateDocs | CheckModule & DocModule |
+
+Legacy files are retained for reference but the DSPy modules above now govern active development.

--- a/agent-rules/dspy/architecture.md
+++ b/agent-rules/dspy/architecture.md
@@ -3,19 +3,21 @@
 ## Signatures
 - `AnalyzeIssue(issue: str) -> AnalysisSpec`
 - `ImplementTask(spec: AnalysisSpec) -> CodePatch`
-- `CommitCode(diff: str) -> CommitMessage`
-- `UpdateDocs(change: CodePatch) -> DocUpdate`
+- `AnalyzeCode(patch: CodePatch) -> CodeReview`
 - `RunChecks(repo: str) -> CheckReport`
+- `UpdateDocs(change: CodePatch) -> DocUpdate`
+- `CommitCode(diff: str) -> CommitMessage`
 
 ## Modules
 - `AnalyzerModule` – `ChainOfThought` reasoning over `AnalyzeIssue`
 - `ImplementerModule` – stepwise planner for `ImplementTask`
-- `CommitModule` – wraps `CommitCode` with pre‑commit enforcement
-- `DocModule` – ensures `UpdateDocs` follows templates
+- `ReviewModule` – evaluates patches via `AnalyzeCode`
 - `CheckModule` – executes test or lint commands and summarizes results
+- `DocModule` – ensures `UpdateDocs` follows templates
+- `CommitModule` – wraps `CommitCode` with pre‑commit enforcement
 
 ## Composition
-`AnalyzerModule` → `ImplementerModule` → `CheckModule` → `CommitModule` → `DocModule`
+`AnalyzerModule` → `ImplementerModule` → `ReviewModule` → `CheckModule` → `DocModule` → `CommitModule`
 
 Each module accepts the previous output, enabling composable workflows.
 

--- a/agent-rules/dspy/integration.md
+++ b/agent-rules/dspy/integration.md
@@ -1,6 +1,6 @@
 # Integration Guidelines
 
-DSPy modules are backend‑agnostic. To use different LMs:
+DSPy modules (`AnalyzerModule`, `ImplementerModule`, `ReviewModule`, `CheckModule`, `DocModule`, `CommitModule`) are backend‑agnostic. To use different LMs:
 
 - **Claude** – instantiate modules with `dspy.Anthropic()`.
 - **Gemini** – instantiate modules with `dspy.OpenAI(model="gemini-pro")`.

--- a/agent-rules/dspy/modules.py
+++ b/agent-rules/dspy/modules.py
@@ -1,7 +1,7 @@
 """DSPy modules orchestrating LM strategies for each signature."""
 
 import dspy
-from .signatures import AnalyzeIssue, ImplementTask, RunChecks, CommitCode, UpdateDocs
+from .signatures import AnalyzeIssue, ImplementTask, AnalyzeCode, RunChecks, CommitCode, UpdateDocs
 
 
 class AnalyzerModule(dspy.Module):
@@ -20,6 +20,14 @@ class ImplementerModule(dspy.Module):
         return self.cot(spec=spec)
 
 
+class ReviewModule(dspy.Module):
+    def __init__(self, lm=None):
+        self.cot = dspy.ChainOfThought(AnalyzeCode, lm=lm)
+
+    def forward(self, patch):
+        return self.cot(patch=patch)
+
+
 class CheckModule(dspy.Module):
     def __init__(self, lm=None):
         self.literal = dspy.Literal(RunChecks, lm=lm)
@@ -28,17 +36,17 @@ class CheckModule(dspy.Module):
         return self.literal(repo=repo)
 
 
-class CommitModule(dspy.Module):
-    def __init__(self, lm=None):
-        self.cot = dspy.ChainOfThought(CommitCode, lm=lm)
-
-    def forward(self, diff: str):
-        return self.cot(diff=diff)
-
-
 class DocModule(dspy.Module):
     def __init__(self, lm=None):
         self.cot = dspy.ChainOfThought(UpdateDocs, lm=lm)
 
     def forward(self, patch):
         return self.cot(patch=patch)
+
+
+class CommitModule(dspy.Module):
+    def __init__(self, lm=None):
+        self.cot = dspy.ChainOfThought(CommitCode, lm=lm)
+
+    def forward(self, diff: str):
+        return self.cot(diff=diff)

--- a/agent-rules/dspy/signatures.py
+++ b/agent-rules/dspy/signatures.py
@@ -15,6 +15,12 @@ class ImplementTask(dspy.Signature):
     patch = dspy.OutputField(desc="proposed code patch and file list")
 
 
+class AnalyzeCode(dspy.Signature):
+    """Evaluate a code patch for quality, performance, and security."""
+    patch = dspy.InputField(desc="proposed code patch")
+    report = dspy.OutputField(desc="quality, performance, and security findings")
+
+
 class RunChecks(dspy.Signature):
     """Execute tests or linters and summarize results."""
     repo = dspy.InputField(desc="path to repository")

--- a/agent-rules/legacy-rules/README.md
+++ b/agent-rules/legacy-rules/README.md
@@ -5,4 +5,4 @@ This directory contains the original agent instructions prior to the DSPy refact
 - `global/` – cross-project rules and setup scripts
 - `project/` – task‑specific guidelines such as commits, issue analysis, and documentation
 
-These files have not been translated into DSPy signatures. Prefer the new `dspy/` rulebook for active development.
+These files have not been translated into DSPy signatures. Prefer `dspy/DSPY_RULES.md` for active development and consult `dspy/TRACEABILITY.md` for mappings from these legacy files to their DSPy successors.


### PR DESCRIPTION
## Summary
- add `AnalyzeCode` signature and `ReviewModule` for quality and security review
- rename rulebook to `DSPY_RULES.md` and document precedence hierarchy
- provide traceability mapping from legacy `.mdc` files to DSPy modules

## Testing
- `python -m py_compile agent-rules/dspy/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0e8245d5c83288e72d8a7bc776777